### PR TITLE
Contraint les iframes à ne pas dépasser la largeur de l'écran

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -233,6 +233,10 @@ img {
   max-width: 100%;
 }
 
+iframe {
+  max-width: 100%;
+}
+
 .blog-item {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Idéalement, il faut appliquer un attribut `style="aspect-ratio: <width>/<height>;"` dans l'`iframe`.