### PR TITLE
Sélection des pages dans le menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,10 +5,11 @@
     <nav>
       <ul>
         {% comment %}
-          The nav_pages variable construction could be simplified with Jekyll 4+ expressions, but we're using Jekyll 3.9 
+          The nav_pages variable construction could be simplified with Jekyll 4+ complex where_exp expressions, 
+          but we're using Jekyll 3.9 
         {% endcomment %}
-        {% assign true_menu_pages = site.pages | where: "in_menu", true %}
-        {% assign nil_menu_pages = site.pages | where: "in_menu", nil %}
+        {% assign true_menu_pages = site.pages | where_exp: "page", "page.in_menu == true" %}
+        {% assign nil_menu_pages = site.pages | where_exp: "page", "page.in_menu == nil" %}
 
         {% assign nav_pages = true_menu_pages | concat: nil_menu_pages | sort: "order" %}
         {% for page in nav_pages %} 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,13 @@
   <div class="container">
     <nav>
       <ul>
-        {% assign nav_pages = site.pages | where_exp: "page", "page.in_menu == true or page.in_menu == nil" | sort: "order" %}
+        {% comment %}
+          The nav_pages variable construction could be simplified with Jekyll 4+ expressions, but we're using Jekyll 3.9 
+        {% endcomment %}
+        {% assign true_menu_pages = site.pages | where: "in_menu", true %}
+        {% assign nil_menu_pages = site.pages | where: "in_menu", nil %}
+
+        {% assign nav_pages = true_menu_pages | concat: nil_menu_pages | sort: "order" %}
         {% for page in nav_pages %} 
         <li>
           <a href="{{page.url | prepend: site.baseurl }}">{{page.title}}</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
   <div class="container">
     <nav>
       <ul>
-        {% assign nav_pages = site.pages | where_exp:"in_menu", "in_menu == true or in_menu == nil" | sort: "order" %}
+        {% assign nav_pages = site.pages | where_exp: "page", "page.in_menu == true or page.in_menu == nil" | sort: "order" %}
         {% for page in nav_pages %} 
         <li>
           <a href="{{page.url | prepend: site.baseurl }}">{{page.title}}</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
   <div class="container">
     <nav>
       <ul>
-        {% assign nav_pages = site.pages | sort: "order" %}
+        {% assign nav_pages = site.pages | where_exp:"in_menu", "in_menu == true or in_menu == nil" | sort: "order" %}
         {% for page in nav_pages %} 
         <li>
           <a href="{{page.url | prepend: site.baseurl }}">{{page.title}}</a>


### PR DESCRIPTION
J'ai fait le choix de nommer la propriété positivement "in_menu" parce que ça évite les lecture de double négatif genre `hide_menu: false`
Quand la propriété n'est pas présente (cas actuel pour tous les sites, valeur `nil` en Jekyll), on affiche quand même l'élément dans le menu