### PR TITLE
Ajout d'une gemspec

### DIFF
--- a/mimoza.gemspec
+++ b/mimoza.gemspec
@@ -16,8 +16,15 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_runtime_dependency "jekyll", "~> 4.0"
-  spec.add_runtime_dependency "jekyll-feed", "~> 0.9"
-  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
+  spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.16"
+  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
+  spec.add_runtime_dependency "jekyll-feed", "~> 0.17"
+  spec.add_runtime_dependency "jekyll-paginate-v2", "~> 3.0"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.8"
+  spec.add_runtime_dependency "jekyll-optional-front-matter", "~> 0.3"
+  spec.add_runtime_dependency "jekyll-default-layout", "~> 0.1.5"
+  spec.add_runtime_dependency "jekyll-titles-from-headings", "~> 0.5.3"
+
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/mimoza.gemspec
+++ b/mimoza.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |spec|
     f.match(%r!^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)
   end
 
-  spec.add_runtime_dependency "jekyll", ">= 3.5", "< 5.0"
+  spec.add_runtime_dependency "jekyll", "~> 4.0"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.9"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
 
-  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 12.0"
 end

--- a/mimoza.gemspec
+++ b/mimoza.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.license     = "MIT"
 
   spec.metadata["plugin_type"] = "theme"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.files = `git ls-files -z`.split("\x0").select do |f|
     f.match(%r!^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)

--- a/mimoza.gemspec
+++ b/mimoza.gemspec
@@ -1,0 +1,23 @@
+Gem::Specification.new do |spec|
+  spec.name        = "mimoza"
+  spec.version     = "1.0.0"
+  spec.authors     = ["Scribouilli"]
+  spec.email       = "coucou@scribouilli.org"
+
+  spec.summary     = "Mimoza, a Jekyll theme"
+  spec.homepage    = "https://git.scribouilli.org/scribouilli/mimoza"
+  spec.description = "Mimoza is a Jekyll theme for Scribouilli."
+  spec.license     = "MIT"
+
+  spec.metadata["plugin_type"] = "theme"
+
+  spec.files = `git ls-files -z`.split("\x0").select do |f|
+    f.match(%r!^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)
+  end
+
+  spec.add_runtime_dependency "jekyll", ">= 3.5", "< 5.0"
+  spec.add_runtime_dependency "jekyll-feed", "~> 0.9"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
+
+  spec.add_development_dependency "bundler"
+end

--- a/mimoza.gemspec
+++ b/mimoza.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     f.match(%r!^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)
   end
 
-  spec.add_runtime_dependency "jekyll", "~> 4.0"
+  spec.add_runtime_dependency "jekyll", "~> 4.3.2"
   spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.16"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.17"


### PR DESCRIPTION
Lié à https://github.com/Scribouilli/scribouilli/issues/126#issuecomment-1830544117 et https://github.com/Scribouilli/scribouilli/issues/76

## Description

Afin de pouvoir installer ce thème via les [GitHub Actions](https://docs.github.com/en/actions) et [GitLab CI](https://docs.gitlab.com/ee/ci/), on a besoin que ce thème soit structuré comme une gem Ruby. Cette PR ajoute donc un fichier `mimoza.gemspec` pour cela.